### PR TITLE
increased seed generation attempts

### DIFF
--- a/packages/core/lib/graph/fill.ts
+++ b/packages/core/lib/graph/fill.ts
@@ -322,17 +322,14 @@ const graphFill = (
 
 export const generateSeed = (seed: number, settings: Settings) => {
   const maxOuterLoop = 20;
-  let maxInnerLoop = 10;
+  let maxInnerLoop = 40;
   const rnd = new DotNetRandom(seed);
 
   if (settings.majorDistribution == MajorDistributionMode.Chozo) {
-    maxInnerLoop = 50;
+    maxInnerLoop *= 5;
   }
   if (!settings.randomizeAreas) {
     maxInnerLoop *= 10;
-  }
-  if (settings.bossMode == BossMode.Vanilla) {
-    maxInnerLoop *= 2;
   }
 
   let attempts = 1;


### PR DESCRIPTION
With the recent fix to logic in West Maridia, we found at least 1 seed out of 1000000 that failed to generate. By increasing the number attempts, we now can generate all 1000000.